### PR TITLE
Add basic usage guides

### DIFF
--- a/Guias/Cursos.php
+++ b/Guias/Cursos.php
@@ -1,0 +1,24 @@
+<?php include '../Modulos/Head.php'; ?>
+<div class="page-inner">
+  <div class="page-header">
+    <h4 class="page-title">Guía de Cursos</h4>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="card">
+        <div class="card-body">
+          <h5>Agregar un curso</h5>
+          <p>En el módulo <strong>Cursos</strong> selecciona <em>Registrar Nuevo Curso</em> y completa el formulario.</p>
+          <h5>Modificar un curso</h5>
+          <p>Desde la lista de cursos elige <em>Editar</em> junto al curso que deseas modificar.</p>
+          <h5>Ver contenido</h5>
+          <p>Haz clic en el botón <em>Contenido</em> para administrar las clases y material del curso.</p>
+          <h5>Reuniones</h5>
+          <p>En la vista de contenido podrás agregar enlaces y fechas de reuniones para los participantes.</p>
+          <a class="btn btn-primary mt-3" href="index.php">Volver al menú de guías</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<?php include '../Modulos/Footer.php'; ?>

--- a/Guias/Inscripciones.php
+++ b/Guias/Inscripciones.php
@@ -1,0 +1,22 @@
+<?php include '../Modulos/Head.php'; ?>
+<div class="page-inner">
+  <div class="page-header">
+    <h4 class="page-title">Guía de Inscripciones</h4>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="card">
+        <div class="card-body">
+          <p>Desde este apartado puedes:</p>
+          <ul>
+            <li>Registrar nuevas inscripciones a los cursos disponibles.</li>
+            <li>Validar o rechazar los comprobantes de pago enviados por los participantes.</li>
+            <li>Cambiar el estado de cada participación (pendiente, pago validado, rechazado, etc.).</li>
+          </ul>
+          <a class="btn btn-primary mt-3" href="index.php">Volver al menú de guías</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<?php include '../Modulos/Footer.php'; ?>

--- a/Guias/Participantes.php
+++ b/Guias/Participantes.php
@@ -1,0 +1,17 @@
+<?php include '../Modulos/Head.php'; ?>
+<div class="page-inner">
+  <div class="page-header">
+    <h4 class="page-title">Guía de Participantes</h4>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="card">
+        <div class="card-body">
+          <p>En esta sección podrás consultar la información de cada participante y actualizar sus datos de contacto.</p>
+          <a class="btn btn-primary mt-3" href="index.php">Volver al menú de guías</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<?php include '../Modulos/Footer.php'; ?>

--- a/Guias/index.php
+++ b/Guias/index.php
@@ -1,0 +1,20 @@
+<?php include '../Modulos/Head.php'; ?>
+<div class="page-inner">
+  <div class="page-header">
+    <h4 class="page-title">Guías de Uso</h4>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="card">
+        <div class="card-body">
+          <ul>
+            <li><a href="Cursos.php">Guía de Cursos</a></li>
+            <li><a href="Inscripciones.php">Guía de Inscripciones</a></li>
+            <li><a href="Participantes.php">Guía de Participantes</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<?php include '../Modulos/Footer.php'; ?>

--- a/Modulos/Head.php
+++ b/Modulos/Head.php
@@ -197,6 +197,9 @@ if (empty($_SESSION['idAdmin'])) {
         <a class="nav-link" href="/Usuarios/index.php"><i class="fas fa-user"></i>Usuarios <span class="sr-only"></span></a>
 
       </li>
+      <li class="nav-item ">
+        <a class="nav-link" href="/Guias/index.php"><i class="fas fa-book"></i>Guías <span class="sr-only"></span></a>
+      </li>
 
             </ul>
 


### PR DESCRIPTION
## Summary
- create basic menu for guides
- document steps for managing courses
- add placeholder instructions for inscriptions and participants
- detail that inscriptions can reject receipts or change status
- link guide menu from navigation

## Testing
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_68631338d3288322b85474ed653b9d5a