### PR TITLE
Add participants cleanup interface

### DIFF
--- a/Participantes/eliminar.php
+++ b/Participantes/eliminar.php
@@ -1,0 +1,143 @@
+<?php
+session_start();
+require_once '../DB/Conexion.php';
+$database = new Database();
+$conn = $database->getConnection();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    header('Content-Type: application/json');
+    $id_curso = intval($_POST['id_curso'] ?? 0);
+    if ($id_curso <= 0) {
+        echo json_encode(['success' => false, 'message' => 'ID de curso inválido']);
+        exit();
+    }
+
+    $conn->begin_transaction();
+    try {
+        $stmt = $conn->prepare("SELECT DISTINCT id_participante FROM inscripciones WHERE id_curso = ? AND (comprobante_path IS NULL OR comprobante_path = '')");
+        $stmt->bind_param("i", $id_curso);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $participantes = [];
+        while ($row = $result->fetch_assoc()) {
+            $participantes[] = $row['id_participante'];
+        }
+        $stmt->close();
+
+        if (empty($participantes)) {
+            echo json_encode(['success' => false, 'message' => 'No hay participantes para eliminar']);
+            exit();
+        }
+
+        $stmtDelIns = $conn->prepare("DELETE FROM inscripciones WHERE id_curso = ? AND id_participante = ?");
+        foreach ($participantes as $id_part) {
+            $stmtDelIns->bind_param("ii", $id_curso, $id_part);
+            $stmtDelIns->execute();
+        }
+        $stmtDelIns->close();
+
+        $stmtCheck = $conn->prepare("SELECT COUNT(*) AS total FROM inscripciones WHERE id_participante = ?");
+        $stmtDelPart = $conn->prepare("DELETE FROM participantes WHERE id_participante = ?");
+        foreach ($participantes as $id_part) {
+            $stmtCheck->bind_param("i", $id_part);
+            $stmtCheck->execute();
+            $res = $stmtCheck->get_result()->fetch_assoc();
+            if ($res['total'] == 0) {
+                $stmtDelPart->bind_param("i", $id_part);
+                $stmtDelPart->execute();
+            }
+        }
+        $stmtCheck->close();
+        $stmtDelPart->close();
+
+        $conn->commit();
+        echo json_encode(['success' => true, 'message' => 'Participantes eliminados: ' . count($participantes)]);
+    } catch (Exception $e) {
+        $conn->rollback();
+        error_log('Error al eliminar participantes: ' . $e->getMessage());
+        echo json_encode(['success' => false, 'message' => 'Error del servidor']);
+    }
+    exit();
+}
+
+include '../Modulos/Head.php';
+
+$query = "SELECT c.id_curso, c.nombre_curso,
+                 (SELECT COUNT(*) FROM inscripciones i WHERE i.id_curso = c.id_curso AND (i.comprobante_path IS NULL OR i.comprobante_path = '')) AS sin_comprobante
+           FROM cursos c
+           WHERE c.activo = 1
+           ORDER BY c.nombre_curso";
+$resultCursos = $conn->query($query);
+?>
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title">Eliminar participantes sin comprobante</h4>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-striped table-bordered" id="cursosTable">
+                        <thead class="thead-dark">
+                            <tr>
+                                <th>ID</th>
+                                <th>Curso</th>
+                                <th>Sin comprobante</th>
+                                <th class="text-center">Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php while ($curso = $resultCursos->fetch_assoc()): ?>
+                                <tr>
+                                    <td><?php echo $curso['id_curso']; ?></td>
+                                    <td><?php echo htmlspecialchars($curso['nombre_curso']); ?></td>
+                                    <td><?php echo $curso['sin_comprobante']; ?></td>
+                                    <td class="text-center">
+                                        <button class="btn btn-danger btn-sm eliminar-participantes" data-id="<?php echo $curso['id_curso']; ?>">
+                                            <i class="fas fa-trash"></i> Eliminar
+                                        </button>
+                                    </td>
+                                </tr>
+                            <?php endwhile; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php include '../Modulos/Footer.php'; ?>
+<script>
+$(function(){
+    $('.eliminar-participantes').click(function(){
+        const idCurso = $(this).data('id');
+        Swal.fire({
+            title: '¿Eliminar inscritos sin comprobante?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sí, eliminar',
+            cancelButtonText: 'Cancelar'
+        }).then((result) => {
+            if(result.isConfirmed){
+                $.ajax({
+                    url: 'eliminar.php',
+                    type: 'POST',
+                    data: {id_curso: idCurso},
+                    dataType: 'json',
+                    success: function(res){
+                        if(res.success){
+                            Swal.fire('Éxito', res.message, 'success');
+                            setTimeout(() => location.reload(), 1000);
+                        } else {
+                            Swal.fire('Error', res.message, 'error');
+                        }
+                    },
+                    error: function(){
+                        Swal.fire('Error', 'No se pudo conectar con el servidor.', 'error');
+                    }
+                });
+            }
+        });
+    });
+});
+</script>

--- a/Participantes/index.php
+++ b/Participantes/index.php
@@ -33,7 +33,10 @@ if ($result_curso->num_rows > 0) {
     <button type="submit" class="btn btn-primary mb-3">
         <i class="fas fa-envelope"></i> Enviar correo a todos los inscritos
     </button>
-</form>
+    </form>
+    <a href="eliminar.php" class="btn btn-danger mb-3 ms-2">
+        <i class="fas fa-user-slash"></i> Eliminar participantes
+    </a>
   <div class="col-md-12">
     <div class="card">
       <div class="card-header">


### PR DESCRIPTION
## Summary
- implement deletion UI in `Participantes/eliminar.php`
- list active courses and allow removing inscriptions without proof
- cascade delete unused participants
- add link from participants page to the cleanup screen

## Testing
- `php -l Participantes/index.php` *(fails: php not installed)*
- `php -l Participantes/eliminar.php` *(fails: php not installed)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68632ef46f208322a251c89d20f2eebb