### PR TITLE
Add cedula profile field

### DIFF
--- a/Registro.php
+++ b/Registro.php
@@ -18,6 +18,7 @@ if ($clave_curso) {
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $curso) {
     $nombre = htmlspecialchars($_POST['nombre']);
     $apellido = htmlspecialchars($_POST['apellido']);
+    $cedula = htmlspecialchars($_POST['cedula']);
     $email = filter_var($_POST['email'], FILTER_SANITIZE_EMAIL);
     $telefono = htmlspecialchars($_POST['telefono']);
     $titulo = $_POST['titulo'];
@@ -32,9 +33,9 @@ $pass_hash = password_hash($pass_plain, PASSWORD_DEFAULT);
         $_SESSION['pass_temporal'] = $pass_plain;
         
         // Registrar participante
-       $sql_participante = "INSERT INTO participantes (nombre, apellido, email, telefono,pass,titulo) VALUES (?, ?, ?, ?, ?,?)";
+       $sql_participante = "INSERT INTO participantes (nombre, apellido, cedula, email, telefono, pass, titulo) VALUES (?, ?, ?, ?, ?, ?, ?)";
         $stmt_participante = $database->getConnection()->prepare($sql_participante);
-        $stmt_participante->bind_param("ssssss", $nombre, $apellido, $email, $telefono, $pass_hash,$titulo);
+        $stmt_participante->bind_param("sssssss", $nombre, $apellido, $cedula, $email, $telefono, $pass_hash, $titulo);
 
         if ($stmt_participante->execute()) {
             $id_participante = $stmt_participante->insert_id;
@@ -183,6 +184,11 @@ $pass_hash = password_hash($pass_plain, PASSWORD_DEFAULT);
                                 <div class="mb-3">
                                     <label for="telefono" class="form-label">Teléfono*</label>
                                     <input type="tel" class="form-control" id="telefono" name="telefono" required>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label for="cedula" class="form-label">Cédula*</label>
+                                    <input type="text" class="form-control" id="cedula" name="cedula" required>
                                 </div>
 
                                 <div class="mb-3 d-none" id="otroTituloDiv">

--- a/participantePanel/mi_perfil.php
+++ b/participantePanel/mi_perfil.php
@@ -14,10 +14,10 @@ $conn = $database->getConnection();
 $id_participante = $_SESSION['participante_id'];
 
 // Obtener datos actuales
-$stmt = $conn->prepare("SELECT nombre, apellido, titulo FROM participantes WHERE id_participante = ?");
+$stmt = $conn->prepare("SELECT nombre, apellido, cedula, titulo FROM participantes WHERE id_participante = ?");
 $stmt->bind_param("i", $id_participante);
 $stmt->execute();
-$stmt->bind_result($nombre, $apellido, $titulo);
+$stmt->bind_result($nombre, $apellido, $cedula, $titulo);
 $stmt->fetch();
 $stmt->close();
 ?>
@@ -35,6 +35,10 @@ $stmt->close();
         <div class="mb-3">
             <label class="form-label">Apellido</label>
             <input type="text" name="apellido" class="form-control" value="<?= htmlspecialchars($apellido) ?>" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Cédula</label>
+            <input type="text" name="cedula" class="form-control" value="<?= htmlspecialchars($cedula) ?>" required>
         </div>
         <div class="mb-3">
             <label class="form-label">Título / Grado</label>

--- a/participantePanel/procesar_edicion_nombre.php
+++ b/participantePanel/procesar_edicion_nombre.php
@@ -12,10 +12,11 @@ if (!isset($_SESSION['participante_id'])) {
 $id = $_POST['id'] ?? null;
 $nombre = trim($_POST['nombre'] ?? '');
 $apellido = trim($_POST['apellido'] ?? '');
+$cedula = trim($_POST['cedula'] ?? '');
 $titulo = trim($_POST['titulo'] ?? '');
 $titulo_otro = trim($_POST['titulo_otro'] ?? '');
 
-if (!$id || !$nombre || !$apellido || !$titulo) {
+if (!$id || !$nombre || !$apellido || !$cedula || !$titulo) {
     header("Location: mi_perfil.php?error=campos_obligatorios");
     exit();
 }
@@ -29,8 +30,8 @@ try {
     $database = new Database();
     $conn = $database->getConnection();
 
-    $stmt = $conn->prepare("UPDATE participantes SET nombre = ?, apellido = ?, titulo = ? WHERE id_participante = ?");
-    $stmt->bind_param("sssi", $nombre, $apellido, $titulo, $id);
+    $stmt = $conn->prepare("UPDATE participantes SET nombre = ?, apellido = ?, cedula = ?, titulo = ? WHERE id_participante = ?");
+    $stmt->bind_param("ssssi", $nombre, $apellido, $cedula, $titulo, $id);
 
     if ($stmt->execute()) {
         header("Location: mi_perfil.php?success=perfil_actualizado");


### PR DESCRIPTION
## Summary
- support a new `cedula` field for participants
- allow editing a participant's cedula from their profile page
- remove the `add_cedula.sql` migration file

## Testing
- `php -l Registro.php` *(fails: `php` not found)*
- `php -l participantePanel/procesar_edicion_nombre.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644ba3eab883228ab653db56a81b89