### PR TITLE
Show prefix example in CSV export form

### DIFF
--- a/Participantes/exportar_csv.php
+++ b/Participantes/exportar_csv.php
@@ -1,0 +1,37 @@
+<?php
+require_once '../DB/Conexion.php';
+$database = new Database();
+
+$id_curso = isset($_POST['id_curso']) ? intval($_POST['id_curso']) : 0;
+$prefijo = trim($_POST['prefijo'] ?? '');
+
+header('Content-Type: text/csv; charset=utf-8');
+header('Content-Disposition: attachment; filename="participantes_curso_'.$id_curso.'.csv"');
+
+$output = fopen('php://output', 'w');
+fputcsv($output, ['id_participante', 'titulo', 'nombre', 'apellido', 'cedula', 'email']);
+
+$query = $database->getConnection()->prepare(
+    "SELECT p.id_participante, p.titulo, p.nombre, p.apellido, p.cedula, p.email
+     FROM inscripciones i
+     INNER JOIN participantes p ON i.id_participante = p.id_participante
+     WHERE i.id_curso = ? AND i.estado = 'pago_validado'");
+$query->bind_param('i', $id_curso);
+$query->execute();
+$result = $query->get_result();
+
+while ($row = $result->fetch_assoc()) {
+    $id = $row['id_participante'];
+    if ($prefijo !== '') {
+        if (strpos($prefijo, '@id') !== false) {
+            $id = str_replace('@id', $id, $prefijo);
+        } else {
+            $id = $prefijo . $id;
+        }
+    }
+    fputcsv($output, [$id, $row['titulo'], $row['nombre'], $row['apellido'], $row['cedula'], $row['email']]);
+}
+
+fclose($output);
+exit;
+?>

--- a/Participantes/index.php
+++ b/Participantes/index.php
@@ -28,11 +28,21 @@ if ($result_curso->num_rows > 0) {
 ?>
 
 <div class="row">
-    <form method="POST" action="enviar_correo_masivo.php" target="_blank">
+    <form method="POST" action="enviar_correo_masivo.php" target="_blank" class="mb-3 me-3">
     <input type="hidden" name="id_curso" value="<?php echo $id_curso; ?>">
-    <button type="submit" class="btn btn-primary mb-3">
+    <button type="submit" class="btn btn-primary">
         <i class="fas fa-envelope"></i> Enviar correo a todos los inscritos
     </button>
+    </form>
+    <form method="POST" action="exportar_csv.php" class="mb-3">
+        <input type="hidden" name="id_curso" value="<?php echo $id_curso; ?>">
+        <div class="input-group">
+            <input type="text" name="prefijo" id="prefijo" class="form-control" placeholder="Prefijo">
+            <button type="submit" class="btn btn-success">
+                <i class="fas fa-file-csv"></i> Pasar a CSV
+            </button>
+        </div>
+        <label for="prefijo" class="form-label mt-1">Ejemplo: 1-002-@id</label>
     </form>
   <div class="col-md-12">
     <div class="card">


### PR DESCRIPTION
## Summary
- show example prefix format in the participant CSV export form
- keep export logic for validated participants with optional prefix

## Testing
- `php -l Participantes/exportar_csv.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686525da60e08322a2c8cd96ad3669a6