### PR TITLE
Implement multiple payment receipts

### DIFF
--- a/DB/Conexion.php
+++ b/DB/Conexion.php
@@ -370,8 +370,9 @@ if ($row['requiere_pago'] == 1) {
         // Consulta mejorada para incluir comprobante_path
         $query = "SELECT 
                 i.id_inscripcion, 
-                i.id_curso, 
+                i.id_curso,
                 i.id_participante,
+                i.id_opcion_pago,
                 i.estado,
                 i.metodo_pago,
                 i.monto_pagado,
@@ -407,6 +408,7 @@ if ($row['requiere_pago'] == 1) {
                     'pendiente_pago' => 'bg-warning',
                     'comprobante_enviado' => 'bg-info',
                     'revision_pago' => 'bg-primary',
+                    'pagos_programados' => 'bg-info',
                     'pago_validado' => 'bg-success',
                     'rechazado' => 'bg-danger'
                 ];
@@ -445,8 +447,15 @@ if ($row['requiere_pago'] == 1) {
                     <div class="btn-group btn-group-sm">
                         <button class="btn btn-primary" onclick="editarInscripcion(' . $row['id_inscripcion'] . ')" title="Editar">
                             <i class="fas fa-edit"></i>
-                        </button>
+                        </button>';
 
+                if (!$row['id_opcion_pago']) {
+                    $html .= '<button class="btn btn-success asignar-opcion" data-id="' . $row['id_inscripcion'] . '">
+                            <i class="fas fa-calendar-plus"></i>
+                        </button>';
+                }
+
+                $html .= '
                         <div class="btn-group">
                             <button type="button" class="btn btn-warning dropdown-toggle" data-bs-toggle="dropdown" title="Cambiar estado">
                                 <i class="fas fa-exchange-alt"></i>

--- a/DB/migrations/2025_07_02_add_comprobantes_inscripcion.sql
+++ b/DB/migrations/2025_07_02_add_comprobantes_inscripcion.sql
@@ -1,0 +1,18 @@
+-- SQL script to modify database for multiple payment receipts
+
+-- Add new column to inscripciones table for linking payment option
+ALTER TABLE inscripciones
+    ADD COLUMN id_opcion_pago INT NULL AFTER id_participante;
+
+-- Table to store each payment receipt of an inscription
+CREATE TABLE comprobantes_inscripcion (
+    id_comprobante INT AUTO_INCREMENT PRIMARY KEY,
+    id_inscripcion INT NOT NULL,
+    numero_pago INT NOT NULL,
+    metodo_pago VARCHAR(100) NOT NULL,
+    referencia_pago VARCHAR(255) NOT NULL,
+    monto_pagado DECIMAL(10,2) NOT NULL,
+    comprobante_path VARCHAR(255) NOT NULL,
+    fecha_carga TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (id_inscripcion) REFERENCES inscripciones(id_inscripcion)
+);

--- a/Participantes/gestion_inscripcion.php
+++ b/Participantes/gestion_inscripcion.php
@@ -68,9 +68,9 @@ try {
         if (empty($nuevo_estado)) {
             throw new Exception('El estado es requerido');
         }
-        $stmt = $database->getConnection()->prepare("UPDATE inscripciones 
-            SET estado = ?, 
-                fecha_cambio_estado = CURRENT_TIMESTAMP 
+        $stmt = $database->getConnection()->prepare("UPDATE inscripciones
+            SET estado = ?,
+                fecha_cambio_estado = CURRENT_TIMESTAMP
             WHERE id_inscripcion = ?");
         $stmt->bind_param("si", $nuevo_estado, $id_inscripcion);
         $stmt->execute();
@@ -78,6 +78,23 @@ try {
         echo json_encode([
             'success' => true,
             'message' => 'Estado de inscripción actualizado correctamente'
+        ]);
+    } elseif ($accion === 'asignar_opcion_pago') {
+        $id_opcion = $data['id_opcion'] ?? 0;
+        if (!$id_opcion) {
+            throw new Exception('Opción de pago no válida');
+        }
+        $stmt = $database->getConnection()->prepare("UPDATE inscripciones
+            SET id_opcion_pago = ?,
+                estado = 'pagos_programados',
+                fecha_cambio_estado = CURRENT_TIMESTAMP
+            WHERE id_inscripcion = ?");
+        $stmt->bind_param("ii", $id_opcion, $id_inscripcion);
+        $stmt->execute();
+
+        echo json_encode([
+            'success' => true,
+            'message' => 'Opción de pago asignada'
         ]);
     } else {
         throw new Exception('Acción no válida');

--- a/participantePanel/curso/info.php
+++ b/participantePanel/curso/info.php
@@ -102,11 +102,17 @@ $data = $result->fetch_assoc();
                                         
                                         <?php if ($data['estado'] == 'registrado' && $data['requiere_pago']): ?>
                                             <hr>
-                                            <button class="btn btn-primary open-modal" 
-                                                    data-inscripcion="<?= $data['id_inscripcion'] ?>" 
-                                                    data-curso="<?= htmlspecialchars($data['nombre_curso']) ?>">
-                                                <i class="fas fa-upload"></i> Subir comprobante
-                                            </button>
+                                            <?php if ($data['id_opcion_pago']): ?>
+                                                <a href="../pagos.php?id=<?= $data['id_inscripcion'] ?>" class="btn btn-primary">
+                                                    <i class="fas fa-receipt"></i> Ver pagos
+                                                </a>
+                                            <?php else: ?>
+                                                <button class="btn btn-primary open-modal"
+                                                        data-inscripcion="<?= $data['id_inscripcion'] ?>"
+                                                        data-curso="<?= htmlspecialchars($data['nombre_curso']) ?>">
+                                                    <i class="fas fa-upload"></i> Subir comprobante
+                                                </button>
+                                            <?php endif; ?>
                                         <?php endif; ?>
                                     </div>
                                     

--- a/participantePanel/index.php
+++ b/participantePanel/index.php
@@ -12,7 +12,7 @@ require_once '../DB/Conexion.php';
 $database = new Database();
 
 $participante_id = $_SESSION['participante_id'];
-$query = "SELECT i.id_inscripcion, c.clave_curso, c.nombre_curso, i.estado, i.fecha_inscripcion 
+$query = "SELECT i.id_inscripcion, i.id_opcion_pago, c.clave_curso, c.nombre_curso, i.estado, i.fecha_inscripcion
           FROM inscripciones i
           JOIN cursos c ON i.id_curso = c.id_curso
           WHERE i.id_participante = ?";
@@ -64,13 +64,19 @@ $stmtCedula->close();
                       </span>
                     </td>
                     <td>
-                      <?php if ($row['estado'] == 'registrado'): ?>
-                        <button class="btn btn-sm btn-primary open-modal" 
-                                data-inscripcion="<?= $row['id_inscripcion'] ?>" 
+                    <?php if ($row['estado'] == 'registrado'): ?>
+                      <?php if ($row['id_opcion_pago']): ?>
+                          <a href="pagos.php?id=<?= $row['id_inscripcion'] ?>" class="btn btn-sm btn-primary">
+                              <i class="fas fa-receipt"></i> Ver pagos
+                          </a>
+                      <?php else: ?>
+                          <button class="btn btn-sm btn-primary open-modal"
+                                data-inscripcion="<?= $row['id_inscripcion'] ?>"
                                 data-curso="<?= htmlspecialchars($row['nombre_curso']) ?>">
-                            <i class="fas fa-upload"></i> Subir comprobante
-                        </button>
+                              <i class="fas fa-upload"></i> Subir comprobante
+                          </button>
                       <?php endif; ?>
+                    <?php endif; ?>
                        <?php if ($row['estado'] == 'pago_validado'): ?>
                         <a href="curso/contenido.php?clave=<?= $row['clave_curso'] ?>" class="btn btn-sm btn-primary">
 

--- a/participantePanel/pagos.php
+++ b/participantePanel/pagos.php
@@ -1,0 +1,158 @@
+<?php
+session_start();
+if (!isset($_SESSION['participante_id'])) {
+    header("Location: login.php");
+    exit();
+}
+
+require_once '../DB/Conexion.php';
+include '../Modulos/HeadP.php';
+
+$id_inscripcion = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if ($id_inscripcion <= 0) {
+    header("Location: index.php");
+    exit();
+}
+
+$database = new Database();
+$conn = $database->getConnection();
+
+// Verificar que la inscripción pertenece al participante y obtener datos del curso y opción de pago
+$stmt = $conn->prepare("SELECT i.id_inscripcion, i.id_opcion_pago, c.nombre_curso, op.numero_pagos
+                       FROM inscripciones i
+                       JOIN cursos c ON i.id_curso = c.id_curso
+                       LEFT JOIN opciones_pago op ON i.id_opcion_pago = op.id_opcion
+                       WHERE i.id_inscripcion = ? AND i.id_participante = ?");
+$stmt->bind_param("ii", $id_inscripcion, $_SESSION['participante_id']);
+$stmt->execute();
+$result = $stmt->get_result();
+
+if ($result->num_rows === 0) {
+    $stmt->close();
+    $database->closeConnection();
+    header("Location: index.php");
+    exit();
+}
+
+$inscripcion = $result->fetch_assoc();
+$stmt->close();
+
+// Si no tiene opción de pago (es null) regresar a index para usar el modal habitual
+if (!$inscripcion['id_opcion_pago']) {
+    $database->closeConnection();
+    header("Location: index.php");
+    exit();
+}
+
+$numero_pagos = (int)($inscripcion['numero_pagos'] ?? 1);
+
+$pagos = [];
+$pagosStmt = $conn->prepare("SELECT numero_pago, metodo_pago, referencia_pago, monto_pagado, comprobante_path, fecha_carga
+                              FROM comprobantes_inscripcion
+                              WHERE id_inscripcion = ?
+                              ORDER BY numero_pago");
+$pagosStmt->bind_param("i", $id_inscripcion);
+$pagosStmt->execute();
+$resPagos = $pagosStmt->get_result();
+while ($row = $resPagos->fetch_assoc()) {
+    $pagos[] = $row;
+}
+$pagosStmt->close();
+?>
+<div class="container mt-4">
+    <h3 class="mb-4">Pagos de <?= htmlspecialchars($inscripcion['nombre_curso']) ?></h3>
+
+    <table class="table table-bordered">
+        <thead class="table-light">
+            <tr>
+                <th># Pago</th>
+                <th>Método</th>
+                <th>Referencia</th>
+                <th>Monto</th>
+                <th>Comprobante</th>
+                <th>Fecha</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (count($pagos) > 0): ?>
+                <?php foreach ($pagos as $pago): ?>
+                <tr>
+                    <td><?= $pago['numero_pago'] ?></td>
+                    <td><?= htmlspecialchars($pago['metodo_pago']) ?></td>
+                    <td><?= htmlspecialchars($pago['referencia_pago']) ?></td>
+                    <td>$<?= number_format($pago['monto_pagado'], 2) ?></td>
+                    <td><a href="../comprobantes/<?= htmlspecialchars($pago['comprobante_path']) ?>" target="_blank">Ver</a></td>
+                    <td><?= date('d/m/Y', strtotime($pago['fecha_carga'])) ?></td>
+                </tr>
+                <?php endforeach; ?>
+            <?php else: ?>
+                <tr><td colspan="6" class="text-center">Sin comprobantes cargados</td></tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
+
+<?php if (count($pagos) < $numero_pagos): ?>
+    <h5 class="mt-4">Subir comprobante (<?= count($pagos)+1 ?> de <?= $numero_pagos ?>)</h5>
+    <form id="formComprobante" enctype="multipart/form-data" class="mt-3">
+        <input type="hidden" name="id_inscripcion" value="<?= $id_inscripcion ?>">
+        <div class="mb-3">
+            <label class="form-label">Método de Pago</label>
+            <select name="metodo_pago" class="form-control" required>
+                <option value="">Seleccionar...</option>
+                <option value="Transferencia">Transferencia Bancaria</option>
+                <option value="Deposito">Depósito</option>
+                <option value="Paypal">PayPal</option>
+                <option value="Tarjeta">Tarjeta de Crédito/Débito</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Referencia de Pago</label>
+            <input type="text" name="referencia_pago" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Monto Pagado</label>
+            <input type="number" step="0.01" name="monto_pagado" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Comprobante (PDF/Imagen)</label>
+            <input type="file" name="comprobante" class="form-control" accept=".pdf,.jpg,.jpeg,.png" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Enviar Comprobante</button>
+    </form>
+<?php else: ?>
+    <div class="alert alert-info mt-4">Se enviaron todos los comprobantes requeridos.</div>
+<?php endif; ?>
+</div>
+
+<script>
+document.getElementById('formComprobante')?.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const formData = new FormData(this);
+    const submitBtn = this.querySelector('button[type="submit"]');
+    submitBtn.disabled = true;
+    submitBtn.innerHTML = 'Enviando...';
+
+    fetch('subir_comprobante.php', {
+        method: 'POST',
+        body: formData
+    }).then(r => r.json())
+    .then(data => {
+        if (data.success) {
+            alert(data.message);
+            window.location.reload();
+        } else {
+            alert('Error: ' + data.message);
+            submitBtn.disabled = false;
+            submitBtn.innerHTML = 'Enviar Comprobante';
+        }
+    }).catch(err => {
+        console.error(err);
+        alert('Error al enviar el formulario');
+        submitBtn.disabled = false;
+        submitBtn.innerHTML = 'Enviar Comprobante';
+    });
+});
+</script>
+<?php include '../Modulos/FooterP.php';
+$database->closeConnection();
+?>


### PR DESCRIPTION
## Summary
- add migration for `id_opcion_pago` and a new `comprobantes_inscripcion` table
- allow `subir_comprobante.php` to store multiple receipts when an inscription has a payment option
- create a new page to upload each receipt and link to it from the dashboard
- let admins assign a payment option via a modal and mark the inscription as `pagos_programados`

## Testing
- `php -l participantePanel/pagos.php` *(fails: `php` not found)*
- `php -l participantePanel/index.php` *(fails: `php` not found)*
- `php -l DB/Conexion.php` *(fails: `php` not found)*
- `php -l Participantes/index.php` *(fails: `php` not found)*
- `php -l Participantes/gestion_inscripcion.php` *(fails: `php` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6865360e53f083229b43021f53f2dd9d