### PR TITLE
Add admin view for payment receipts

### DIFF
--- a/DB/Conexion.php
+++ b/DB/Conexion.php
@@ -414,14 +414,16 @@ class Database
                 $fecha_inscripcion = date('d/m/Y H:i', strtotime($row['fecha_inscripcion']));
                 $fecha_cambio = $row['fecha_cambio_estado'] ? date('d/m/Y H:i', strtotime($row['fecha_cambio_estado'])) : 'N/A';
 
-                // Botón de comprobante
-                $botonComprobante = $row['comprobante_path']
-                    ? '<button class="btn btn-sm btn-info ver-comprobante" 
-                     data-id="' . $row['id_inscripcion'] . '" 
-                     data-archivo="' . $row['comprobante_path'] . '">
-                     <i class="fas fa-file-invoice"></i> Ver
-                   </button>'
-                    : 'N/A';
+                // Botón o enlace de comprobante según la opción de pago
+                if ($row['id_opcion_pago']) {
+                    // Múltiples pagos: ir a pantalla de gestión
+                    $botonComprobante = '<a href="pagos.php?id=' . $row['id_inscripcion'] . '" class="btn btn-sm btn-info"><i class="fas fa-file-invoice"></i> Ver</a>';
+                } else {
+                    // Pago único: mostrar visor modal existente
+                    $botonComprobante = $row['comprobante_path']
+                        ? '<button class="btn btn-sm btn-info ver-comprobante" data-id="' . $row['id_inscripcion'] . '" data-archivo="' . $row['comprobante_path'] . '"><i class="fas fa-file-invoice"></i> Ver</button>'
+                        : 'N/A';
+                }
 
                 $html .= '
             <tr>

--- a/DB/migrations/2025_07_14_add_validado_to_comprobantes.sql
+++ b/DB/migrations/2025_07_14_add_validado_to_comprobantes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE comprobantes_inscripcion
+    ADD COLUMN validado TINYINT(1) NOT NULL DEFAULT 0 AFTER fecha_carga;

--- a/Participantes/gestion_comprobante.php
+++ b/Participantes/gestion_comprobante.php
@@ -1,0 +1,25 @@
+<?php
+require_once '../DB/Conexion.php';
+header('Content-Type: application/json');
+
+$data = $_POST;
+$accion = $data['accion'] ?? '';
+$id_comprobante = isset($data['id_comprobante']) ? intval($data['id_comprobante']) : 0;
+$validado = isset($data['validado']) ? intval($data['validado']) : 0;
+
+if ($accion !== 'actualizar' || !$id_comprobante || !in_array($validado, [0,1,3])) {
+    echo json_encode(['success'=>false,'message'=>'Datos no válidos']);
+    exit();
+}
+
+$database = new Database();
+$conn = $database->getConnection();
+$stmt = $conn->prepare("UPDATE comprobantes_inscripcion SET validado = ? WHERE id_comprobante = ?");
+$stmt->bind_param("ii", $validado, $id_comprobante);
+if ($stmt->execute()) {
+    echo json_encode(['success'=>true,'message'=>'Estado actualizado']);
+} else {
+    echo json_encode(['success'=>false,'message'=>'Error al actualizar']);
+}
+$database->closeConnection();
+?>

--- a/Participantes/pagos.php
+++ b/Participantes/pagos.php
@@ -1,0 +1,123 @@
+<?php
+require_once '../DB/Conexion.php';
+include '../Modulos/Head.php';
+
+$id_inscripcion = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if ($id_inscripcion <= 0) {
+    echo '<div class="alert alert-danger">ID de inscripción inválido</div>';
+    include '../Modulos/Footer.php';
+    exit();
+}
+
+$database = new Database();
+$conn = $database->getConnection();
+
+$stmt = $conn->prepare("SELECT i.id_inscripcion, i.IdOpcionPago AS id_opcion_pago,
+                       i.metodo_pago, i.referencia_pago, i.monto_pagado,
+                       i.comprobante_path, i.estado, i.fecha_cambio_estado,
+                       c.nombre_curso, op.numero_pagos
+                       FROM inscripciones i
+                       JOIN cursos c ON i.id_curso = c.id_curso
+                       LEFT JOIN opciones_pago op ON i.IdOpcionPago = op.id_opcion
+                       WHERE i.id_inscripcion = ?");
+$stmt->bind_param("i", $id_inscripcion);
+$stmt->execute();
+$result = $stmt->get_result();
+if ($result->num_rows === 0) {
+    echo '<div class="alert alert-warning">Inscripción no encontrada</div>';
+    include '../Modulos/Footer.php';
+    exit();
+}
+$inscripcion = $result->fetch_assoc();
+$stmt->close();
+$numero_pagos = (int)($inscripcion['numero_pagos'] ?? 1);
+$pagos = [];
+$isMultiple = !empty($inscripcion['id_opcion_pago']);
+
+if ($isMultiple) {
+    $pagosStmt = $conn->prepare("SELECT id_comprobante, numero_pago, metodo_pago, referencia_pago, monto_pagado, comprobante_path, fecha_carga, validado
+                                  FROM comprobantes_inscripcion
+                                  WHERE id_inscripcion = ?
+                                  ORDER BY numero_pago");
+    $pagosStmt->bind_param("i", $id_inscripcion);
+    $pagosStmt->execute();
+    $resPagos = $pagosStmt->get_result();
+    while ($row = $resPagos->fetch_assoc()) {
+        $pagos[] = $row;
+    }
+    $pagosStmt->close();
+} else {
+    if ($inscripcion['comprobante_path']) {
+        $pagos[] = [
+            'numero_pago'     => 1,
+            'metodo_pago'     => $inscripcion['metodo_pago'],
+            'referencia_pago' => $inscripcion['referencia_pago'],
+            'monto_pagado'    => $inscripcion['monto_pagado'],
+            'comprobante_path'=> $inscripcion['comprobante_path'],
+            'fecha_carga'     => $inscripcion['fecha_cambio_estado'],
+            'validado'        => $inscripcion['estado'] === 'pago_validado' ? 1 : 0
+        ];
+    }
+}
+?>
+<div class="container mt-4">
+    <h3 class="mb-4">Pagos de <?= htmlspecialchars($inscripcion['nombre_curso']) ?></h3>
+    <table class="table table-bordered">
+        <thead class="table-light">
+            <tr>
+                <th># Pago</th>
+                <th>Método</th>
+                <th>Referencia</th>
+                <th>Monto</th>
+                <th>Comprobante</th>
+                <th>Fecha</th>
+                <th><?= $isMultiple ? 'Validado' : 'Estado' ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (count($pagos) > 0): ?>
+                <?php foreach ($pagos as $pago): ?>
+                <tr>
+                    <td><?= $pago['numero_pago'] ?></td>
+                    <td><?= htmlspecialchars($pago['metodo_pago']) ?></td>
+                    <td><?= htmlspecialchars($pago['referencia_pago']) ?></td>
+                    <td>$<?= number_format($pago['monto_pagado'], 2) ?></td>
+                    <td><a href="../comprobantes/<?= htmlspecialchars($pago['comprobante_path']) ?>" target="_blank">Ver</a></td>
+                    <td><?= date('d/m/Y', strtotime($pago['fecha_carga'])) ?></td>
+                    <td>
+                        <?php if ($isMultiple): ?>
+                            <select class="form-select form-select-sm validar-select" data-id="<?= $pago['id_comprobante'] ?>">
+                                <option value="0" <?= $pago['validado']==0?'selected':'' ?>>Pendiente</option>
+                                <option value="1" <?= $pago['validado']==1?'selected':'' ?>>Correcto</option>
+                                <option value="3" <?= $pago['validado']==3?'selected':'' ?>>Rechazado</option>
+                            </select>
+                        <?php else: ?>
+                            <?= htmlspecialchars($inscripcion['estado']) ?>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            <?php else: ?>
+                <tr><td colspan="7" class="text-center">Sin comprobantes cargados</td></tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
+</div>
+<script>
+$(function(){
+    $('.validar-select').change(function(){
+        const id = $(this).data('id');
+        const val = $(this).val();
+        $.post('gestion_comprobante.php',{accion:'actualizar',id_comprobante:id,validado:val},function(res){
+            if(res.success){
+                Swal.fire('Éxito', res.message, 'success');
+            }else{
+                Swal.fire('Error', res.message, 'error');
+            }
+        },'json');
+    });
+});
+</script>
+<?php include '../Modulos/Footer.php';
+$database->closeConnection();
+?>


### PR DESCRIPTION
## Summary
- add new migration to track validation status for payment receipts
- create admin view to list and validate payments
- allow updates of receipt validation status via new endpoint
- link inscripciones table to the new payment screen
- support existing single-payment receipts

## Testing
- ❌ `php -l DB/Conexion.php` (failed to run: `php: command not found`)
- ❌ `php -l Participantes/pagos.php` (failed to run: `php: command not found`)
- ❌ `php -l Participantes/gestion_comprobante.php` (failed to run: `php: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_6865e93268d0832292b74fd14fb61627