### PR TITLE
Add participant document upload

### DIFF
--- a/DB/Conexion.php
+++ b/DB/Conexion.php
@@ -359,6 +359,7 @@ class Database
                     <th>Método Pago</th>
                     <th>Monto</th>
                     <th>Comprobante</th>
+                    <th>Documento</th>
                     <th>Acciones</th>
                 </tr>
             </thead>
@@ -380,7 +381,8 @@ class Database
                 p.nombre as nombre_participante,
                 p.apellido as apellido_participante,
                 p.email as email_participante,
-                p.telefono as telefono_participante
+                p.telefono as telefono_participante,
+                p.documento
               FROM inscripciones i
               LEFT JOIN cursos c ON i.id_curso = c.id_curso
               LEFT JOIN participantes p ON i.id_participante = p.id_participante";
@@ -426,6 +428,11 @@ class Database
                         : 'N/A';
                 }
 
+                // Documento de estudios
+                $botonDocumento = $row['documento']
+                    ? '<a href="../documentos/' . $row['documento'] . '" target="_blank" class="btn btn-sm btn-info"><i class="fas fa-file"></i> Ver</a>'
+                    : '<span class="text-danger">No subido</span>';
+
                 $html .= '
             <tr>
                 <td>' . $row["id_inscripcion"] . '</td>
@@ -443,6 +450,7 @@ class Database
                 <td>' . ($row["metodo_pago"] ?: 'N/A') . '</td>
                 <td class="text-end">' . ($row["monto_pagado"] ? '$' . number_format($row["monto_pagado"], 2) : 'N/A') . '</td>
                 <td class="text-center">' . $botonComprobante . '</td>
+                <td class="text-center">' . $botonDocumento . '</td>
                 <td class="text-center">
                     <div class="btn-group btn-group-sm">
                         <button class="btn btn-primary" onclick="editarInscripcion(' . $row['id_inscripcion'] . ')" title="Editar">

--- a/DB/migrations/2025_07_30_add_documento_to_participantes.sql
+++ b/DB/migrations/2025_07_30_add_documento_to_participantes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE participantes
+    ADD COLUMN documento VARCHAR(255) NULL AFTER titulo;

--- a/participantePanel/index.php
+++ b/participantePanel/index.php
@@ -21,11 +21,11 @@ $stmt->bind_param("i", $participante_id);
 $stmt->execute();
 $result = $stmt->get_result();
 
-// Obtener cédula del participante
-$stmtCedula = $database->getConnection()->prepare("SELECT cedula FROM participantes WHERE id_participante = ?");
+// Obtener cédula y documento del participante
+$stmtCedula = $database->getConnection()->prepare("SELECT cedula, documento FROM participantes WHERE id_participante = ?");
 $stmtCedula->bind_param("i", $participante_id);
 $stmtCedula->execute();
-$stmtCedula->bind_result($cedula);
+$stmtCedula->bind_result($cedula, $documento);
 $stmtCedula->fetch();
 $stmtCedula->close();
 ?>
@@ -124,12 +124,32 @@ $stmtCedula->close();
                   <i class="fas fa-plus"></i> Agregar Curso
                 </button>
               </form>
-              <div id="mensajeClave" class="mt-2"></div>
-            </div>
-          </div>
+          <div id="mensajeClave" class="mt-2"></div>
+        </div>
+      </div>
+      <div class="card col-lg-4 mb-4">
+        <div class="card-header">
+          <h5>Documento de Estudios</h5>
+        </div>
+        <div class="card-body">
+          <?php if ($documento): ?>
+            <a href="../documentos/<?= htmlspecialchars($documento) ?>" target="_blank" class="btn btn-info mb-2">
+              <i class="fas fa-file"></i> Ver Documento
+            </a>
+            <p>Si deseas reemplazarlo, sube uno nuevo.</p>
+          <?php else: ?>
+            <div class="alert alert-warning">Es importante subir tu documento.</div>
+          <?php endif; ?>
+          <form id="formDocumento" enctype="multipart/form-data">
+            <input type="file" name="documento" class="form-control-file" accept=".pdf,.jpg,.jpeg,.png" required>
+            <button type="submit" class="btn btn-primary mt-2">Subir documento</button>
+          </form>
+          <div id="msgDocumento" class="mt-2"></div>
         </div>
       </div>
     </div>
+  </div>
+</div>
   </div>
 </div>
 
@@ -335,6 +355,29 @@ endwhile;
       .finally(() => {
         boton.disabled = false;
         boton.innerHTML = '<i class="fas fa-plus"></i> Agregar Curso';
+      });
+  });
+
+  // Subir documento de estudios
+  document.getElementById('formDocumento').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const formData = new FormData(this);
+    const btn = this.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Subiendo...';
+    fetch('subir_documento.php', { method: 'POST', body: formData })
+      .then(r => r.json())
+      .then(d => {
+        const div = document.getElementById('msgDocumento');
+        div.innerHTML = `<div class="alert alert-${d.success ? 'success' : 'danger'}">${d.message}</div>`;
+        if (d.success) setTimeout(() => location.reload(), 1000);
+      })
+      .catch(() => {
+        document.getElementById('msgDocumento').innerHTML = '<div class="alert alert-danger">Error en la conexión</div>';
+      })
+      .finally(() => {
+        btn.disabled = false;
+        btn.innerHTML = 'Subir documento';
       });
   });
 

--- a/participantePanel/subir_documento.php
+++ b/participantePanel/subir_documento.php
@@ -1,0 +1,59 @@
+<?php
+session_start();
+require_once '../DB/Conexion.php';
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['participante_id']) || $_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'message' => 'Acceso no autorizado']);
+    exit();
+}
+
+$database = new Database();
+$conn = $database->getConnection();
+$id = $_SESSION['participante_id'];
+
+try {
+    if (!isset($_FILES['documento'])) {
+        throw new Exception('No se envió archivo');
+    }
+
+    $target_dir = '../documentos/';
+    $nombre_archivo = uniqid() . '_' . basename($_FILES['documento']['name']);
+    $target_file = $target_dir . $nombre_archivo;
+
+    $ext = strtolower(pathinfo($target_file, PATHINFO_EXTENSION));
+    if (!in_array($ext, ['pdf','jpg','jpeg','png'])) {
+        throw new Exception('Formato no permitido');
+    }
+    if ($_FILES['documento']['size'] > 2097152) {
+        throw new Exception('El archivo supera 2MB');
+    }
+
+    $stmt = $conn->prepare('SELECT documento FROM participantes WHERE id_participante = ?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $stmt->bind_result($docActual);
+    $stmt->fetch();
+    $stmt->close();
+
+    if (!move_uploaded_file($_FILES['documento']['tmp_name'], $target_file)) {
+        throw new Exception('Error al guardar archivo');
+    }
+
+    if ($docActual) {
+        @unlink($target_dir . $docActual);
+    }
+
+    $stmt = $conn->prepare('UPDATE participantes SET documento = ? WHERE id_participante = ?');
+    $stmt->bind_param('si', $nombre_archivo, $id);
+    if (!$stmt->execute()) {
+        @unlink($target_file);
+        throw new Exception('Error al actualizar registro');
+    }
+
+    echo json_encode(['success' => true, 'message' => 'Documento cargado correctamente']);
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+} finally {
+    $database->closeConnection();
+}


### PR DESCRIPTION
## Summary
- let participants store a study document
- show a card to upload or replace document in participant panel
- expose document column in participant table
- support viewing documents from admin interface

## Testing
- `php` syntax check *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672c99d8488322a58221f927425894