### PR TITLE
Allow progressive access based on payments

### DIFF
--- a/DB/Conexion.php
+++ b/DB/Conexion.php
@@ -729,14 +729,15 @@ public function getOpcionesPagoCurso() {
     return $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
 }
 public function getContenidoCursoParticipante($id_curso) {
-    $query = "SELECT 
-                id_contenido, 
-                titulo, 
-                descripcion, 
-                tipo_contenido, 
-                archivo_ruta, 
+    $query = "SELECT
+                id_contenido,
+                titulo,
+                descripcion,
+                tipo_contenido,
+                archivo_ruta,
                 enlace_url,
-                fecha_publicacion
+                fecha_publicacion,
+                PagoPorce
               FROM contenido_curso
               WHERE id_curso = ?
               ORDER BY orden, fecha_publicacion DESC";
@@ -750,7 +751,7 @@ public function getContenidoCursoParticipante($id_curso) {
 }
 
 public function getReunionesZoomParticipante($id_curso) {
-    $query = "SELECT 
+    $query = "SELECT
                 id_reunion,
                 titulo,
                 descripcion,
@@ -758,7 +759,8 @@ public function getReunionesZoomParticipante($id_curso) {
                 duracion_minutos,
                 url_zoom,
                 codigo_acceso,
-                grabacion_url
+                grabacion_url,
+                PagoPorce
               FROM reuniones_zoom
               WHERE id_curso = ?
               ORDER BY fecha_hora DESC";

--- a/participantePanel/index.php
+++ b/participantePanel/index.php
@@ -12,7 +12,11 @@ require_once '../DB/Conexion.php';
 $database = new Database();
 
 $participante_id = $_SESSION['participante_id'];
-$query = "SELECT i.id_inscripcion, i.IdOpcionPago as id_opcion_pago, c.clave_curso, c.nombre_curso, i.estado, i.fecha_inscripcion
+$query = "SELECT i.id_inscripcion, i.IdOpcionPago as id_opcion_pago, c.clave_curso, c.nombre_curso, i.estado, i.fecha_inscripcion,
+                 COALESCE((SELECT SUM(monto_pagado)
+                           FROM comprobantes_inscripcion ci
+                           WHERE ci.validado = 1
+                             AND ci.id_inscripcion = i.id_inscripcion), 0) AS total_pagado
           FROM inscripciones i
           JOIN cursos c ON i.id_curso = c.id_curso
           WHERE i.id_participante = ?";
@@ -77,7 +81,7 @@ $stmtCedula->close();
                           </button>
 
                         <?php endif; ?>
-                        <?php if ($row['estado'] == 'pago_validado'): ?>
+                        <?php if ($row['estado'] == 'pago_validado' || $row['total_pagado'] > 0): ?>
                           <a href="curso/contenido.php?clave=<?= $row['clave_curso'] ?>" class="btn btn-sm btn-primary">
 
                             Ir al Curso


### PR DESCRIPTION
## Summary
- expose PagoPorce in DB queries
- calculate validated payment totals per inscription
- hide content and meetings until required payment percentage is met

## Testing
- `php -l participantePanel/curso/contenido.php` *(fails: php not installed)*
- `php -l participantePanel/curso/reuniones.php` *(fails: php not installed)*
- `php -l DB/Conexion.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68673d842f188322a329f62c63fd25c8