### PR TITLE
Add adjustable payment amount field

### DIFF
--- a/DB/Conexion.php
+++ b/DB/Conexion.php
@@ -424,7 +424,12 @@ class Database
                 } else {
                     // Pago único: mostrar visor modal existente
                     $botonComprobante = $row['comprobante_path']
-                        ? '<button class="btn btn-sm btn-info ver-comprobante" data-id="' . $row['id_inscripcion'] . '" data-archivo="' . $row['comprobante_path'] . '"><i class="fas fa-file-invoice"></i> Ver</button>'
+                        ? '<button class="btn btn-sm btn-info ver-comprobante"'
+                        . ' data-id="' . $row['id_inscripcion'] . '"'
+                        . ' data-archivo="' . $row['comprobante_path'] . '"'
+                        . ' data-monto="' . $row['monto_pagado'] . '">
+                            <i class="fas fa-file-invoice"></i> Ver
+                          </button>'
                         : 'N/A';
                 }
 

--- a/Participantes/gestion_inscripcion.php
+++ b/Participantes/gestion_inscripcion.php
@@ -18,12 +18,14 @@ try {
     $id_inscripcion = $data['id_inscripcion'] ?? 0;
     
     if ($accion === 'aprobar') {
-        // Aprobar comprobante
-        $stmt = $database->getConnection()->prepare("UPDATE inscripciones 
-            SET estado = 'pago_validado', 
-                fecha_cambio_estado = CURRENT_TIMESTAMP 
+        // Aprobar comprobante y actualizar monto
+        $monto = isset($data['monto_pagado']) ? (float)$data['monto_pagado'] : null;
+        $stmt = $database->getConnection()->prepare("UPDATE inscripciones
+            SET estado = 'pago_validado',
+                monto_pagado = ?,
+                fecha_cambio_estado = CURRENT_TIMESTAMP
             WHERE id_inscripcion = ?");
-        $stmt->bind_param("i", $id_inscripcion);
+        $stmt->bind_param("di", $monto, $id_inscripcion);
         $stmt->execute();
         
         echo json_encode([

--- a/Participantes/index.php
+++ b/Participantes/index.php
@@ -94,6 +94,11 @@ $stmtOpc->close();
                     <div id="visorDocumento" class="text-center mb-3" style="min-height: 500px;">
                         <!-- Contenido dinámico -->
                     </div>
+
+                    <div class="mb-3">
+                        <label for="montoDeclarado" class="form-label">Monto declarado</label>
+                        <input type="number" step="0.01" class="form-control" id="montoDeclarado">
+                    </div>
                     
                     <form id="formRechazo" class="d-none">
                         <input type="hidden" name="id_inscripcion" id="idInscripcionRechazo">
@@ -187,9 +192,11 @@ $stmtOpc->close();
         $(".ver-comprobante").click(function() {
             const idInscripcion = $(this).data("id");
             const archivo = $(this).data("archivo");
+            const monto = $(this).data("monto");
             const extension = archivo.split(".").pop().toLowerCase();
             
             $("#idInscripcionRechazo").val(idInscripcion);
+            $("#montoDeclarado").val(monto);
             $("#formRechazo").addClass("d-none");
             $("#btnAprobar, #btnRechazar").show();
             
@@ -235,7 +242,8 @@ $stmtOpc->close();
                         type: "POST",
                         data: {
                             accion: "aprobar",
-                            id_inscripcion: idInscripcion
+                            id_inscripcion: idInscripcion,
+                            monto_pagado: $("#montoDeclarado").val()
                         },
                         success: function(response) {
                             if (response.success) {


### PR DESCRIPTION
## Summary
- include `data-monto` attribute for payment amount in participants table
- show `Monto declarado` input in the comprobante modal
- send the new amount when approving a payment
- update approval logic to store the adjusted amount

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dec2c7d7883229643f8dbc897bb39