### PR TITLE
Add CSV export link on participant page

### DIFF
--- a/Participantes/exportar_csv.php
+++ b/Participantes/exportar_csv.php
@@ -2,34 +2,41 @@
 require_once '../DB/Conexion.php';
 $database = new Database();
 
-$id_curso = isset($_POST['id_curso']) ? intval($_POST['id_curso']) : 0;
-$prefijo = trim($_POST['prefijo'] ?? '');
+$id_curso = isset($_POST['id_curso']) ? intval($_POST['id_curso']) : (isset($_GET['id_curso']) ? intval($_GET['id_curso']) : 0);
 
 header('Content-Type: text/csv; charset=utf-8');
-header('Content-Disposition: attachment; filename="participantes_curso_'.$id_curso.'.csv"');
+header('Content-Disposition: attachment; filename="reporte_curso_'.$id_curso.'.csv"');
 
 $output = fopen('php://output', 'w');
-fputcsv($output, ['id_participante', 'titulo', 'nombre', 'apellido', 'cedula', 'email']);
+fputcsv($output, ['titulo', 'nombre_completo', 'monto_validado', 'fecha_inscripcion']);
 
-$query = $database->getConnection()->prepare(
-    "SELECT p.id_participante, p.titulo, p.nombre, p.apellido, p.cedula, p.email
+$conn = $database->getConnection();
+$query = $conn->prepare(
+    "SELECT i.id_inscripcion, i.IdOpcionPago, i.monto_pagado, i.estado, i.fecha_inscripcion, p.titulo,
+            CONCAT(p.nombre, ' ', p.apellido) AS nombre_completo
      FROM inscripciones i
-     INNER JOIN participantes p ON i.id_participante = p.id_participante
-     WHERE i.id_curso = ? AND i.estado = 'pago_validado'");
+     JOIN participantes p ON i.id_participante = p.id_participante
+     WHERE i.id_curso = ? AND (i.estado = 'pago_validado' OR i.estado = 'pagos programados')"
+);
 $query->bind_param('i', $id_curso);
 $query->execute();
 $result = $query->get_result();
 
 while ($row = $result->fetch_assoc()) {
-    $id = $row['id_participante'];
-    if ($prefijo !== '') {
-        if (strpos($prefijo, '@id') !== false) {
-            $id = str_replace('@id', $id, $prefijo);
-        } else {
-            $id = $prefijo . $id;
-        }
+    $monto_validado = 0;
+    if ($row['IdOpcionPago']) {
+        $sum = $conn->prepare("SELECT SUM(monto_pagado) AS total FROM comprobantes_inscripcion WHERE id_inscripcion = ? AND validado = 1");
+        $sum->bind_param('i', $row['id_inscripcion']);
+        $sum->execute();
+        $res = $sum->get_result();
+        $monto_validado = $res->fetch_assoc()['total'] ?? 0;
+        $sum->close();
+    } elseif ($row['estado'] === 'pago_validado') {
+        $monto_validado = $row['monto_pagado'];
     }
-    fputcsv($output, [$id, $row['titulo'], $row['nombre'], $row['apellido'], $row['cedula'], $row['email']]);
+
+    $fecha = date('d/m/Y', strtotime($row['fecha_inscripcion']));
+    fputcsv($output, [$row['titulo'], $row['nombre_completo'], $monto_validado, $fecha]);
 }
 
 fclose($output);

--- a/Participantes/index.php
+++ b/Participantes/index.php
@@ -44,7 +44,7 @@ $stmtOpc->close();
         <i class="fas fa-envelope"></i> Enviar correo a todos los inscritos
     </button>
     </form>
-    <form method="POST" action="exportar_csv.php" class="mb-3">
+    <form method="POST" action="exportar_csv.php" class="mb-3 me-3">
         <input type="hidden" name="id_curso" value="<?php echo $id_curso; ?>">
         <div class="input-group">
             <input type="text" name="prefijo" id="prefijo" class="form-control" placeholder="Prefijo">
@@ -54,6 +54,9 @@ $stmtOpc->close();
         </div>
         <label for="prefijo" class="form-label mt-1">Ejemplo: 1-002-@id</label>
     </form>
+    <a href="exportar_csv.php?id_curso=<?php echo $id_curso; ?>" class="btn btn-secondary mb-3">
+        <i class="fas fa-download"></i> Descargar reporte CSV
+    </a>
   <div class="col-md-12">
     <div class="card">
       <div class="card-header">


### PR DESCRIPTION
## Summary
- add direct link to CSV report on the participant index page

## Testing
- `php -l Participantes/exportar_csv.php`
- `php -l Participantes/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6871481788f48322b96edc176bde315d