### PR TITLE
Add server-side participant table

### DIFF
--- a/Participantes/lista.php
+++ b/Participantes/lista.php
@@ -117,16 +117,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['enviar_boletin'])) {
                     date_default_timezone_set('America/Mexico_City');
                     $hoy = date('Y-m-d');
                     echo "<p class='text-muted'>Fecha actual: $hoy</p>";
-                    
-                    // Mostrar tabla de todos los participantes sin repetir
-                    $query = $database->getConnection()->query("
-                        SELECT DISTINCT id_participante, nombre, apellido, email, telefono, fecha_registro
-                        FROM participantes
-                        ORDER BY fecha_registro DESC
-                    ");
-                    
-                    if ($query->num_rows > 0) {
-                        echo '<table class="table table-striped">
+                        echo '<table id="participantesTable" class="table table-striped">
                             <thead>
                                 <tr>
                                     <th>#</th>
@@ -134,24 +125,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['enviar_boletin'])) {
                                     <th>Email</th>
                                     <th>Teléfono</th>
                                     <th>Fecha Registro</th>
+                                    <th>Acciones</th>
                                 </tr>
                             </thead>
-                            <tbody>';
-                        
-                        while ($row = $query->fetch_assoc()) {
-                            echo '<tr>
-                                <td>'.$row['id_participante'].'</td>
-                                <td>'.htmlspecialchars($row['nombre']).' '.htmlspecialchars($row['apellido']).'</td>
-                                <td>'.htmlspecialchars($row['email']).'</td>
-                                <td>'.htmlspecialchars($row['telefono']).'</td>
-                                <td>'.$row['fecha_registro'].'</td>
-                            </tr>';
-                        }
-                        
-                        echo '</tbody></table>';
-                    } else {
-                        echo '<div class="alert alert-info">No hay participantes registrados</div>';
-                    }
+                        </table>';
                     ?>
                 </div>
             </div>
@@ -248,6 +225,41 @@ document.getElementById('seleccionarTodos').addEventListener('change', function(
     checkboxes.forEach(function(checkbox) {
         checkbox.checked = event.target.checked;
     });
+});
+
+$(document).on('click', '.reset-pass-btn', function() {
+    var id = $(this).data('id');
+    Swal.fire({
+        title: '¿Restablecer contraseña?',
+        icon: 'question',
+        showCancelButton: true,
+        confirmButtonText: 'Sí, restablecer',
+        cancelButtonText: 'Cancelar'
+    }).then(function(result) {
+        if (result.isConfirmed) {
+            $.post('restablecer_pass.php', {id: id}, function(res) {
+                if (res.success) {
+                    Swal.fire('Nueva contraseña', 'La nueva contraseña es: <strong>' + res.pass + '</strong>', 'success');
+                } else {
+                    Swal.fire('Error', res.message, 'error');
+                }
+            }, 'json').fail(function() {
+                Swal.fire('Error', 'No se pudo conectar con el servidor', 'error');
+            });
+        }
+    });
+});
+
+new DataTable('#participantesTable', {
+    serverSide: true,
+    ajax: {
+        url: 'participantes_data.php',
+        type: 'POST'
+    },
+    pageLength: 50,
+    language: {
+        url: '//cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json'
+    }
 });
 </script>
 

--- a/Participantes/participantes_data.php
+++ b/Participantes/participantes_data.php
@@ -1,0 +1,83 @@
+<?php
+require_once '../DB/Conexion.php';
+
+header('Content-Type: application/json');
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$draw = isset($_POST['draw']) ? intval($_POST['draw']) : 0;
+$start = isset($_POST['start']) ? intval($_POST['start']) : 0;
+$length = isset($_POST['length']) ? intval($_POST['length']) : 10;
+$search = $_POST['search']['value'] ?? '';
+
+$columns = [
+    0 => 'id_participante',
+    1 => 'nombre',
+    2 => 'email',
+    3 => 'telefono',
+    4 => 'fecha_registro'
+];
+
+$orderIdx = $_POST['order'][0]['column'] ?? 4;
+$orderDir = $_POST['order'][0]['dir'] ?? 'desc';
+$orderColumn = $columns[$orderIdx] ?? 'fecha_registro';
+
+$totalResult = $conn->query('SELECT COUNT(*) AS cnt FROM participantes');
+$totalRecords = $totalResult->fetch_assoc()['cnt'];
+
+$where = '';
+$params = [];
+$types = '';
+if ($search !== '') {
+    $where = 'WHERE nombre LIKE ? OR apellido LIKE ? OR email LIKE ? OR telefono LIKE ?';
+    $searchLike = "%{$search}%";
+    $params = [$searchLike, $searchLike, $searchLike, $searchLike];
+    $types = 'ssss';
+}
+
+$recordsFiltered = $totalRecords;
+if ($where) {
+    $stmt = $conn->prepare("SELECT COUNT(*) AS cnt FROM participantes $where");
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $recordsFiltered = $res->fetch_assoc()['cnt'];
+    $stmt->close();
+}
+
+$sql = "SELECT id_participante, nombre, apellido, email, telefono, fecha_registro FROM participantes";
+if ($where) {
+    $sql .= " $where";
+}
+$sql .= " ORDER BY $orderColumn $orderDir LIMIT ?, ?";
+
+$params[] = $start;
+$params[] = $length;
+$types .= 'ii';
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param($types, ...$params);
+$stmt->execute();
+$result = $stmt->get_result();
+
+$data = [];
+while ($row = $result->fetch_assoc()) {
+    $data[] = [
+        $row['id_participante'],
+        htmlspecialchars($row['nombre'].' '.$row['apellido']),
+        htmlspecialchars($row['email']),
+        htmlspecialchars($row['telefono']),
+        $row['fecha_registro'],
+        "<button class='btn btn-sm btn-warning reset-pass-btn' data-id='{$row['id_participante']}'><i class='fas fa-key'></i> Restablecer</button>"
+    ];
+}
+$stmt->close();
+$db->closeConnection();
+
+echo json_encode([
+    'draw' => $draw,
+    'recordsTotal' => $totalRecords,
+    'recordsFiltered' => $recordsFiltered,
+    'data' => $data
+]);

--- a/Participantes/restablecer_pass.php
+++ b/Participantes/restablecer_pass.php
@@ -1,0 +1,79 @@
+<?php
+require_once '../DB/Conexion.php';
+require_once '../config/env_loader.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'message' => 'Método no permitido']);
+    exit;
+}
+
+$id = isset($_POST['id']) ? intval($_POST['id']) : 0;
+if ($id <= 0) {
+    echo json_encode(['success' => false, 'message' => 'ID inválido']);
+    exit;
+}
+
+$db = new Database();
+$conn = $db->getConnection();
+$stmt = $conn->prepare("SELECT nombre, apellido, email FROM participantes WHERE id_participante = ?");
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$result = $stmt->get_result();
+$participante = $result->fetch_assoc();
+$stmt->close();
+
+if (!$participante) {
+    echo json_encode(['success' => false, 'message' => 'Participante no encontrado']);
+    exit;
+}
+
+$pass_plain = sprintf('%06d', mt_rand(0, 999999));
+$pass_hash = password_hash($pass_plain, PASSWORD_DEFAULT);
+
+$upd = $conn->prepare("UPDATE participantes SET pass = ? WHERE id_participante = ?");
+$upd->bind_param('si', $pass_hash, $id);
+if (!$upd->execute()) {
+    echo json_encode(['success' => false, 'message' => 'Error al actualizar contraseña']);
+    exit;
+}
+$upd->close();
+
+function enviarCorreoRestablecimiento($destino, $nombreCompleto, $password) {
+    cargarEnv();
+    $apiKey = getenv('MAILGUN_API_KEY');
+    $domain = getenv('MAILGUN_DOMAIN');
+    $from   = getenv('MAILGUN_FROM');
+    if (!$apiKey || !$domain || !$from) {
+        return;
+    }
+    $asunto = 'Restablecimiento de contraseña';
+    $html = "<p>Hola {$nombreCompleto},</p>".
+            "<p>Tu contraseña ha sido restablecida. La nueva contraseña temporal es:</p>".
+            "<p style='font-size:18px'><strong>{$password}</strong></p>".
+            "<p>Puedes acceder a la plataforma desde <a href='https://cursos.clinicacerene.com/index.php'>este enlace</a>.</p>".
+            "<p>Te recomendamos cambiarla después de iniciar sesión.</p>";
+
+    $ch = curl_init();
+    curl_setopt_array($ch, [
+        CURLOPT_URL => "https://api.mailgun.net/v3/{$domain}/messages",
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST => true,
+        CURLOPT_USERPWD => $apiKey,
+        CURLOPT_POSTFIELDS => [
+            'from'    => $from,
+            'to'      => $destino,
+            'subject' => $asunto,
+            'html'    => $html
+        ]
+    ]);
+    curl_exec($ch);
+    curl_close($ch);
+}
+
+enviarCorreoRestablecimiento($participante['email'], $participante['nombre'].' '.$participante['apellido'], $pass_plain);
+
+$db->closeConnection();
+
+echo json_encode(['success' => true, 'pass' => $pass_plain]);


### PR DESCRIPTION
## Summary
- use a server-side DataTable to handle the participant list
- support password resets via AJAX with event delegation

## Testing
- `php -l Participantes/lista.php`
- `php -l Participantes/restablecer_pass.php`
- `php -l Participantes/participantes_data.php`


------
https://chatgpt.com/codex/tasks/task_e_687fa3e282888322a3ba9a6b87d60fc5