### PR TITLE
Add payment report with date range filter

### DIFF
--- a/Modulos/Head.php
+++ b/Modulos/Head.php
@@ -82,6 +82,9 @@ if (empty($_SESSION['idAdmin'])) {
       <li class="nav-item ">
       <a class="nav-link" href="/Guias/index.php"><i class="fas fa-book"></i>Guías <span class="sr-only"></span></a>
       </li>
+      <li class="nav-item ">
+      <a class="nav-link" href="/Reportes/index.php"><i class="fas fa-chart-bar"></i>Reportes <span class="sr-only"></span></a>
+      </li>
     </ul>
     </div>
   </div>

--- a/Reportes/exportar_excel.php
+++ b/Reportes/exportar_excel.php
@@ -1,0 +1,48 @@
+<?php
+require_once '../DB/Conexion.php';
+require '../libe/vendor/autoload.php';
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+
+$inicio = $_GET['inicio'] ?? '';
+$fin = $_GET['fin'] ?? '';
+
+if (!$inicio || !$fin) {
+    die('Rango de fechas inválido');
+}
+
+$database = new Database();
+$conn = $database->getConnection();
+
+$stmt = $conn->prepare("SELECT id_comprobante, id_inscripcion, numero_pago, metodo_pago, referencia_pago, monto_pagado, fecha_carga FROM comprobantes_inscripcion WHERE validado = 1 AND DATE(fecha_carga) BETWEEN ? AND ?");
+$stmt->bind_param('ss', $inicio, $fin);
+$stmt->execute();
+$result = $stmt->get_result();
+
+$spreadsheet = new Spreadsheet();
+$sheet = $spreadsheet->getActiveSheet();
+$headers = ['ID Comprobante', 'ID Inscripción', 'Número de Pago', 'Método de Pago', 'Referencia', 'Monto Pagado', 'Fecha'];
+$sheet->fromArray($headers, null, 'A1');
+
+$row = 2;
+while ($r = $result->fetch_assoc()) {
+    $sheet->setCellValue("A{$row}", $r['id_comprobante']);
+    $sheet->setCellValue("B{$row}", $r['id_inscripcion']);
+    $sheet->setCellValue("C{$row}", $r['numero_pago']);
+    $sheet->setCellValue("D{$row}", $r['metodo_pago']);
+    $sheet->setCellValue("E{$row}", $r['referencia_pago']);
+    $sheet->setCellValue("F{$row}", $r['monto_pagado']);
+    $sheet->setCellValue("G{$row}", $r['fecha_carga']);
+    $row++;
+}
+
+$database->closeConnection();
+
+header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+header('Content-Disposition: attachment; filename="reporte_pagos_' . $inicio . '_al_' . $fin . '.xlsx"');
+header('Cache-Control: max-age=0');
+
+$writer = new Xlsx($spreadsheet);
+$writer->save('php://output');
+exit;

--- a/Reportes/index.php
+++ b/Reportes/index.php
@@ -1,0 +1,44 @@
+<?php
+require_once '../DB/Conexion.php';
+$database = new Database();
+$conn = $database->getConnection();
+
+$inicio = $_GET['inicio'] ?? '';
+$fin = $_GET['fin'] ?? '';
+$total = null;
+
+if ($inicio && $fin) {
+    $stmt = $conn->prepare("SELECT SUM(monto_pagado) AS total FROM comprobantes_inscripcion WHERE validado = 1 AND DATE(fecha_carga) BETWEEN ? AND ?");
+    $stmt->bind_param("ss", $inicio, $fin);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $total = $row['total'] ?? 0;
+}
+?>
+<?php include '../Modulos/Head.php'; ?>
+
+<div class="container mt-4">
+    <h2>Reporte de Pagos</h2>
+    <form method="get" class="row g-3 mb-4">
+        <div class="col-md-4">
+            <label for="inicio" class="form-label">Fecha inicio</label>
+            <input type="date" id="inicio" name="inicio" class="form-control" value="<?= htmlspecialchars($inicio) ?>">
+        </div>
+        <div class="col-md-4">
+            <label for="fin" class="form-label">Fecha fin</label>
+            <input type="date" id="fin" name="fin" class="form-control" value="<?= htmlspecialchars($fin) ?>">
+        </div>
+        <div class="col-md-4 align-self-end">
+            <button type="submit" class="btn btn-primary">Filtrar</button>
+        </div>
+    </form>
+    <?php if ($total !== null): ?>
+        <div class="alert alert-info">
+            Total recaudado: $<?= number_format($total, 2) ?>
+        </div>
+        <a class="btn btn-success" href="exportar_excel.php?inicio=<?= urlencode($inicio) ?>&fin=<?= urlencode($fin) ?>">Exportar a Excel</a>
+    <?php endif; ?>
+</div>
+
+<?php $database->closeConnection(); ?>
+<?php include '../Modulos/Footer.php'; ?>


### PR DESCRIPTION
## Summary
- add payments report page with start/end date filters
- compute total validated payments in selected range
- link report page in sidebar navigation
- allow exporting filtered payments to Excel

## Testing
- `php -l Reportes/index.php`
- `php -l Reportes/exportar_excel.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9c30e028083229e9bbd6dddf23177