### PR TITLE
Restrict registration to Gmail addresses

### DIFF
--- a/Registro.php
+++ b/Registro.php
@@ -91,6 +91,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $curso) {
 
     if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
         $error = "Error: Formato de correo electrónico inválido";
+    } elseif (!preg_match('/@gmail\.com$/i', $email)) {
+        $error = "Error: Solo se permiten correos de Gmail";
     } else {
         try {
         // Generar contraseña de 6 dígitos

--- a/participantePanel/Registro.php
+++ b/participantePanel/Registro.php
@@ -54,6 +54,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
         $error = "Error: Formato de correo electrónico inválido";
+    } elseif (!preg_match('/@gmail\.com$/i', $email)) {
+        $error = "Error: Solo se permiten correos de Gmail";
     } elseif (strlen($pass) < 6) {
         $error = "Error: La contraseña debe tener al menos 6 caracteres";
     } elseif ($pass !== $pass_confirm) {
@@ -148,9 +150,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                 </div>
                             </div>
                             <div class="mb-3">
-                                <label for="email" class="form-label">Correo Electrónico*</label>
-                                <input type="email" class="form-control" id="email" name="email" required>
+                                <label for="email" class="form-label">Correo Electrónico (solo Gmail)*</label>
+                                <input type="email" class="form-control" id="email" name="email" required pattern="^[a-zA-Z0-9._%+-]+@gmail\.com$" title="Solo se permiten correos de Gmail">
+                                <div class="invalid-feedback">
+                                    Solo se permiten correos de Gmail(Para compartir contenido de los cursos).
+                                </div>
                             </div>
+                            <script>
+                            document.addEventListener('DOMContentLoaded', function() {
+                                var emailInput = document.getElementById('email');
+                                emailInput.addEventListener('input', function() {
+                                    if (emailInput.validity.patternMismatch) {
+                                        emailInput.classList.add('is-invalid');
+                                    } else {
+                                        emailInput.classList.remove('is-invalid');
+                                    }
+                                });
+                            });
+                            </script>
                             <div class="mb-3">
                                 <label for="telefono" class="form-label">Teléfono*</label>
                                 <input type="tel" class="form-control" id="telefono" name="telefono" required>


### PR DESCRIPTION
## Summary
- enforce Gmail-only email addresses during course registration
- require Gmail addresses in participant panel registration

## Testing
- `php -l Registro.php participantePanel/Registro.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc66846724832297363c7a055164c7