### PR TITLE
Permitir actualización de correo único

### DIFF
--- a/participantePanel/procesar_cambio_email.php
+++ b/participantePanel/procesar_cambio_email.php
@@ -1,0 +1,66 @@
+<?php
+session_start();
+require_once '../DB/Conexion.php';
+
+if (!isset($_SESSION['participante_id'])) {
+    header("Location: login.php");
+    exit();
+}
+
+$participante_id = $_SESSION['participante_id'];
+$email_nuevo = trim($_POST['email_nuevo'] ?? '');
+$email_confirmar = trim($_POST['email_confirmar'] ?? '');
+
+if (empty($email_nuevo) || empty($email_confirmar)) {
+    header("Location: mi_perfil.php?error=campos_obligatorios");
+    exit();
+}
+
+if ($email_nuevo !== $email_confirmar) {
+    header("Location: mi_perfil.php?error=email_confirmacion_incorrecta");
+    exit();
+}
+
+if (!filter_var($email_nuevo, FILTER_VALIDATE_EMAIL)) {
+    header("Location: mi_perfil.php?error=email_invalido");
+    exit();
+}
+
+if (!preg_match('/@gmail\.com$/i', $email_nuevo)) {
+    header("Location: mi_perfil.php?error=email_no_gmail");
+    exit();
+}
+
+try {
+    $database = new Database();
+    $conn = $database->getConnection();
+
+    $stmt = $conn->prepare("SELECT id_participante FROM participantes WHERE email = ? AND id_participante <> ?");
+    $stmt->bind_param("si", $email_nuevo, $participante_id);
+    $stmt->execute();
+    $stmt->store_result();
+
+    if ($stmt->num_rows > 0) {
+        $stmt->close();
+        $conn->close();
+        header("Location: mi_perfil.php?error=email_en_uso");
+        exit();
+    }
+    $stmt->close();
+
+    $update = $conn->prepare("UPDATE participantes SET email = ? WHERE id_participante = ?");
+    $update->bind_param("si", $email_nuevo, $participante_id);
+
+    if ($update->execute()) {
+        $_SESSION['email'] = $email_nuevo;
+        header("Location: mi_perfil.php?success=email_actualizado");
+    } else {
+        header("Location: mi_perfil.php?error=actualizacion_fallida");
+    }
+
+    $update->close();
+    $conn->close();
+} catch (Exception $e) {
+    error_log("Error en cambio de correo: " . $e->getMessage());
+    header("Location: mi_perfil.php?error=error_interno");
+}


### PR DESCRIPTION
## Summary
- Allow participants to update their email address from their profile, requiring confirmation.
- Validate that new emails are unique and belong to Gmail before saving.
- Show real-time feedback when confirming new email address.

## Testing
- `php -l participantePanel/mi_perfil.php`
- `php -l participantePanel/procesar_cambio_email.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf5ec509d08322a6a652519705b394