### PR TITLE
Allow changing payment date when approving receipt

### DIFF
--- a/DB/Conexion.php
+++ b/DB/Conexion.php
@@ -428,13 +428,18 @@ class Database
                     $botonComprobante = $badgePendiente .'<a href="pagos.php?id=' . $row['id_inscripcion'] . '" class="btn btn-sm btn-info"><i class="fas fa-file-invoice"></i> Ver pagos programados</a>';
                 } else {
                     // Pago único: mostrar visor modal existente
-                                       $botonComprobante = $row['comprobante_path']
+                    $fechaPago = ($row['estado'] === 'pago_validado' && !empty($row['fecha_cambio_estado']))
+                        ? date('Y-m-d', strtotime($row['fecha_cambio_estado']))
+                        : '';
+                    $botonComprobante = $row['comprobante_path']
                         ? '<button class="btn btn-sm btn-info ver-comprobante"'
                         . ' data-id="' . $row['id_inscripcion'] . '"'
                         . ' data-archivo="' . $row['comprobante_path'] . '"'
-                        . ' data-monto="' . $row['monto_pagado'] . '">
-                            <i class="fas fa-file-invoice"></i> Ver
-                          </button>'
+                        . ' data-monto="' . $row['monto_pagado'] . '"'
+                        . ' data-fecha="' . $fechaPago . '"'
+                        . '>'
+                        . '    <i class="fas fa-file-invoice"></i> Ver'
+                        . '  </button>'
                         : 'N/A';
                 }
                 $Pagopendiente = '';

--- a/Participantes/gestion_inscripcion.php
+++ b/Participantes/gestion_inscripcion.php
@@ -18,14 +18,15 @@ try {
     $id_inscripcion = $data['id_inscripcion'] ?? 0;
     
     if ($accion === 'aprobar') {
-        // Aprobar comprobante y actualizar monto
+        // Aprobar comprobante y actualizar monto y fecha
         $monto = isset($data['monto_pagado']) ? (float)$data['monto_pagado'] : null;
+        $fecha = !empty($data['fecha_pago']) ? $data['fecha_pago'] . ' 00:00:00' : date('Y-m-d H:i:s');
         $stmt = $database->getConnection()->prepare("UPDATE inscripciones
             SET estado = 'pago_validado',
                 monto_pagado = ?,
-                fecha_cambio_estado = CURRENT_TIMESTAMP
+                fecha_cambio_estado = ?
             WHERE id_inscripcion = ?");
-        $stmt->bind_param("di", $monto, $id_inscripcion);
+        $stmt->bind_param("dsi", $monto, $fecha, $id_inscripcion);
         $stmt->execute();
         
         echo json_encode([

--- a/Participantes/index.php
+++ b/Participantes/index.php
@@ -224,12 +224,13 @@ $stmtOpc->close();
             const idInscripcion = $(this).data("id");
             const archivo = $(this).data("archivo");
             const monto = $(this).data("monto");
+            const fecha = $(this).data("fecha");
             const extension = archivo.split(".").pop().toLowerCase();
-            
+
             $("#idInscripcionRechazo").val(idInscripcion);
             $("#montoDeclarado").val(monto);
             const today = new Date().toISOString().split('T')[0];
-            $("#fechaPago").val(today);
+            $("#fechaPago").val(fecha || today);
             $("#formRechazo").addClass("d-none");
             $("#btnAprobar, #btnRechazar").show();
             

--- a/Participantes/index.php
+++ b/Participantes/index.php
@@ -102,6 +102,11 @@ $stmtOpc->close();
                         <label for="montoDeclarado" class="form-label">Monto declarado</label>
                         <input type="number" step="0.01" class="form-control" id="montoDeclarado">
                     </div>
+
+                    <div class="mb-3">
+                        <label for="fechaPago" class="form-label">Fecha de pago</label>
+                        <input type="date" class="form-control" id="fechaPago" value="<?php echo date('Y-m-d'); ?>">
+                    </div>
                     
                     <form id="formRechazo" class="d-none">
                         <input type="hidden" name="id_inscripcion" id="idInscripcionRechazo">
@@ -223,6 +228,8 @@ $stmtOpc->close();
             
             $("#idInscripcionRechazo").val(idInscripcion);
             $("#montoDeclarado").val(monto);
+            const today = new Date().toISOString().split('T')[0];
+            $("#fechaPago").val(today);
             $("#formRechazo").addClass("d-none");
             $("#btnAprobar, #btnRechazar").show();
             
@@ -269,7 +276,8 @@ $stmtOpc->close();
                         data: {
                             accion: "aprobar",
                             id_inscripcion: idInscripcion,
-                            monto_pagado: $("#montoDeclarado").val()
+                            monto_pagado: $("#montoDeclarado").val(),
+                            fecha_pago: $("#fechaPago").val()
                         },
                         success: function(response) {
                             if (response.success) {


### PR DESCRIPTION
## Summary
- Add date selector in participant receipt approval modal
- Send chosen date when approving receipt
- Store provided approval date in backend instead of current timestamp

## Testing
- `php -l Participantes/index.php`
- `php -l Participantes/gestion_inscripcion.php`


------
https://chatgpt.com/codex/tasks/task_e_68c04210db848322b6c924bca8390684