### PR TITLE
Permitir ajustar fecha de comprobantes

### DIFF
--- a/Participantes/gestion_comprobante.php
+++ b/Participantes/gestion_comprobante.php
@@ -6,18 +6,42 @@ $data = $_POST;
 $accion = $data['accion'] ?? '';
 $id_comprobante = isset($data['id_comprobante']) ? intval($data['id_comprobante']) : 0;
 $validado = isset($data['validado']) ? intval($data['validado']) : 0;
-$nota = trim($_POST['nota'] ?? null);
+$nota = '';
+if (isset($data['nota'])) {
+    $nota = trim($data['nota']);
+}
 $monto_pagado = isset($data['monto_pagado']) ? floatval($data['monto_pagado']) : null;
+$fecha_carga_input = isset($data['fecha_carga']) ? trim($data['fecha_carga']) : '';
+
+$fecha_carga_db = null;
+if ($fecha_carga_input !== '') {
+    $formatosPermitidos = ['Y-m-d\TH:i', 'Y-m-d H:i:s', 'Y-m-d'];
+    foreach ($formatosPermitidos as $formato) {
+        $fecha = DateTime::createFromFormat($formato, $fecha_carga_input);
+        if ($fecha instanceof DateTime && $fecha->format($formato) === $fecha_carga_input) {
+            if ($formato === 'Y-m-d') {
+                $fecha->setTime(0, 0, 0);
+            }
+            $fecha_carga_db = $fecha->format('Y-m-d H:i:s');
+            break;
+        }
+    }
+}
 
 if ($accion !== 'actualizar' || !$id_comprobante || !in_array($validado, [0,1,3]) || $monto_pagado === null) {
     echo json_encode(['success'=>false,'message'=>'Datos no válidos']);
     exit();
 }
 
+if ($fecha_carga_db === null) {
+    echo json_encode(['success'=>false,'message'=>'Fecha no válida']);
+    exit();
+}
+
 $database = new Database();
 $conn = $database->getConnection();
-$stmt = $conn->prepare("UPDATE comprobantes_inscripcion SET validado = ?, nota = ?, monto_pagado = ? WHERE id_comprobante = ?");
-$stmt->bind_param("isdi", $validado, $nota, $monto_pagado, $id_comprobante);
+$stmt = $conn->prepare("UPDATE comprobantes_inscripcion SET validado = ?, nota = ?, monto_pagado = ?, fecha_carga = ? WHERE id_comprobante = ?");
+$stmt->bind_param("isdsi", $validado, $nota, $monto_pagado, $fecha_carga_db, $id_comprobante);
 if ($stmt->execute()) {
     echo json_encode(['success'=>true,'message'=>'Estado actualizado']);
 } else {


### PR DESCRIPTION
## Summary
- Agregar un selector de fecha editable en la vista de pagos para alinear la fecha del comprobante con el documento recibido.
- Enviar la nueva fecha junto con los cambios de estado o monto y validar/guardar el valor en el backend.

## Testing
- php -l Participantes/pagos.php
- php -l Participantes/gestion_comprobante.php

------
https://chatgpt.com/codex/tasks/task_e_68cdde7e2f2c8322b09d854433a5b136