### PR TITLE
Use onclick handler for comprobante viewer (verComprobante)

### DIFF
--- a/DB/Conexion.php
+++ b/DB/Conexion.php
@@ -431,16 +431,18 @@ class Database
                     $fechaPago = ($row['estado'] === 'pago_validado' && !empty($row['fecha_cambio_estado']))
                         ? date('Y-m-d', strtotime($row['fecha_cambio_estado']))
                         : '';
-                    $botonComprobante = $row['comprobante_path']
-                        ? '<button class="btn btn-sm btn-info ver-comprobante"'
-                        . ' data-id="' . $row['id_inscripcion'] . '"'
-                        . ' data-archivo="' . $row['comprobante_path'] . '"'
-                        . ' data-monto="' . $row['monto_pagado'] . '"'
-                        . ' data-fecha="' . $fechaPago . '"'
-                        . '>'
-                        . '    <i class="fas fa-file-invoice"></i> Ver'
-                        . '  </button>'
-                        : 'N/A';
+                    if ($row['comprobante_path']) {
+                        $archivo = json_encode($row['comprobante_path']);
+                        $monto = json_encode($row['monto_pagado']);
+                        $fecha = json_encode($fechaPago);
+                        $botonComprobante = '<button class="btn btn-sm btn-info"'
+                            . ' onclick="verComprobante(' . (int) $row['id_inscripcion'] . ', ' . $archivo . ', ' . $monto . ', ' . $fecha . ')"'
+                            . '>'
+                            . '    <i class="fas fa-file-invoice"></i> Ver'
+                            . '  </button>';
+                    } else {
+                        $botonComprobante = 'N/A';
+                    }
                 }
                 $Pagopendiente = '';
                     if($row['estado'] == 'comprobante_enviado') {

--- a/Participantes/index.php
+++ b/Participantes/index.php
@@ -220,15 +220,11 @@ $stmtOpc->close();
             });
         });
         // Ver comprobante
-        $(".ver-comprobante").click(function() {
-            const idInscripcion = $(this).data("id");
-            const archivo = $(this).data("archivo");
-            const monto = $(this).data("monto");
-            const fecha = $(this).data("fecha");
+        window.verComprobante = function(idInscripcion, archivo, monto, fecha) {
             const today = new Date().toISOString().split('T')[0];
 
             $("#idInscripcionRechazo").val(idInscripcion);
-            $("#montoDeclarado").val(monto);
+            $("#montoDeclarado").val(monto ?? "");
             $("#fechaPago").val(fecha || today);
             $("#formRechazo").addClass("d-none");
             $("#btnAprobar, #btnRechazar").show();
@@ -279,7 +275,7 @@ $stmtOpc->close();
                         </div>
                     `);
                 });
-        });
+        };
         
         // Aprobar comprobante
         $("#btnAprobar").click(function() {


### PR DESCRIPTION
### Motivation
- Reemplazar el mecanismo basado en la clase `ver-comprobante` por una llamada `onclick` que reciba los parámetros necesarios para abrir el visor de comprobantes desde la lista de inscripciones.

### Description
- Cambiado en `DB/Conexion.php` la generación del botón de comprobante para llamar `onclick="verComprobante(id, archivo, monto, fecha)"` en lugar de renderizar atributos `data-*` y depender de la clase `ver-comprobante`.
- Los valores se serializan con `json_encode` en PHP para producir literales JS seguros al incrustar `archivo`, `monto` y `fecha` en la llamada `onclick`.
- En `Participantes/index.php` se expone una función global `window.verComprobante(idInscripcion, archivo, monto, fecha)` que reemplaza el binding jQuery previo: la función abre el modal, rellena `#montoDeclarado` y `#fechaPago` (usando `monto ?? ""` para valores nulos) y mantiene la lógica de previsualización/descarga del comprobante.
- No se cambió la lógica de visualización (imágenes, PDFs o descarga), solo la forma de invocar el visor desde los botones.

### Testing
- No se ejecutaron pruebas automatizadas sobre este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698270e519108322b8dbe39edf77c44c)